### PR TITLE
Quickfix v0.2.5

### DIFF
--- a/ithildin/__init__.py
+++ b/ithildin/__init__.py
@@ -2,7 +2,7 @@ import logging
 
 from mythril.mythril.mythril_config import MythrilConfig
 
-__version__ = '0.2.4'
+__version__ = '0.2.5'
 
 formatter = logging.Formatter('[%(levelname)s\t] %(asctime)s - %(name)s %(message)s')
 

--- a/ithildin/analysis/strategies/roles.py
+++ b/ithildin/analysis/strategies/roles.py
@@ -93,7 +93,9 @@ class RoleBasedAccessControl(AnalysisStrategy):
         elif state.instruction['opcode'] == 'MSTORE' and state.mstate.stack[-2].symbolic is False:
             # Memorize values before being stored to propagate annotations later
             self._mstore_preprocess(state)
-        elif state.instruction['opcode'] == 'SHA3':
+        elif state.instruction['opcode'] == 'SHA3' and \
+                state.mstate.stack[-1].symbolic is False and \
+                state.mstate.stack[-2].symbolic is False:
             # Check if there are annotations for concrete values to be forwarded
             self._sha3_preprocess(state)
         elif state.instruction['opcode'] == 'JUMPI' and {HashedCaller(), HashedRole()}.issubset(state.mstate.stack[-2].annotations):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import pathlib
 from setuptools import find_packages, setup
 
-VERSION = '0.2.4'
+VERSION = '0.2.5'
 CURRENT_DIR = pathlib.Path(__file__).parent
 README = (CURRENT_DIR / 'README.md').read_text()
 PYTHON_REQUIREMENT = '>=3.6.0'


### PR DESCRIPTION
- Added a missing check in RoleBasedAccessControl strategy where an exception would be throws when pre-processing the SHA3 operator and top stack elements are symbolic